### PR TITLE
Add executable permissions step to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ npm install
 # Build the CLI
 npm run build
 
+# Make the compiled file executable
+chmod +x dist/index.js
+
 # Install the cloned CLI globally with npm
 npm i -g .
 ```


### PR DESCRIPTION
## Summary

Adds a `chmod +x dist/index.js` step to the README installation instructions to prevent "permission denied" errors when running the `sky` command after global installation.

## Changes

- Added `chmod +x dist/index.js` step between build and global install in README.md

## Test plan

- Follow the updated installation instructions
- Verify `sky` command runs without permission errors

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)